### PR TITLE
fix: set lato as the default font and use montserrat for headings

### DIFF
--- a/packages/ui-react/src/styles/_custom.scss
+++ b/packages/ui-react/src/styles/_custom.scss
@@ -1,0 +1,8 @@
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: Montserrat, Helvetica, Arial, sans-serif !important;
+}

--- a/packages/ui-react/src/styles/_theme.scss
+++ b/packages/ui-react/src/styles/_theme.scss
@@ -1,6 +1,7 @@
 @use 'variables';
+@use 'custom';
 
-@import url('https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap');
 
 // Colors
 
@@ -15,8 +16,8 @@ $body-color: variables.$white !default;
 
 // Typography
 
-$body-font-family: Montserrat, Helvetica, Arial, sans-serif !default;
-$body-alt-font-family: Montserrat, Helvetica, Arial, sans-serif !default;
+$body-font-family: Lato, Helvetica, Arial, sans-serif !default;
+$body-alt-font-family: Lato, Helvetica, Arial, sans-serif !default;
 
 $body-font-weight-regular: 500 !default;
 $body-font-weight-bold: 700 !default;


### PR DESCRIPTION
https://app.clickup.com/t/86b2pt9td

## Description

<!-- Describe the proposed solution/fix/feature in this pull request here. -->

This PR solves # .

### Steps completed:

<!-- Check all completed steps so we know  -->

According to our definition of done, I have completed the following steps:

- [ ] Acceptance criteria met
- [ ] Unit tests added
- [ ] Docs updated (including config and env variables)
- [ ] Translations added
- [ ] UX tested
- [ ] Browsers / platforms tested
- [ ] Rebased & ready to merge without conflicts
- [ ] Reviewed own code
